### PR TITLE
Add an optional attribute to allow the output poperty to be set to a default value when the xpath expression can not be resolved

### DIFF
--- a/ant-test.xml
+++ b/ant-test.xml
@@ -13,5 +13,16 @@
         <xpath document="pom.xml"
                xpath="/project/version" outputproperty="pomVersion"/>
         <echo>${pomVersion}</echo>
+
+        <!-- when there is no match on the path -->
+        <xpath document="pom.xml"
+               xpath="/project/undefined" outputproperty="undefinedNoDefault"/>
+        <echo>${undefinedNoDefault}</echo>
+
+        <!-- when there is no match on the path using the defaultValue property -->
+        <xpath document="pom.xml"
+               xpath="/project/undefined" outputproperty="undefinedWithDefault"
+               defaultValue="not found"/>
+        <echo>${undefinedWithDefault}</echo>
     </target>
 </project>

--- a/src/main/java/org/wiztools/ant/xpath/XPathTask.java
+++ b/src/main/java/org/wiztools/ant/xpath/XPathTask.java
@@ -12,6 +12,7 @@ public class XPathTask extends Task {
    private String outputProperty = "output";
    private String document;
    private String xpath;
+   private String defaultValue="";
    private XPathEvaluator evaluator;
    private String delimiter = " ";
    private Boolean multiNodeResult = Boolean.FALSE;
@@ -29,7 +30,15 @@ public class XPathTask extends Task {
       checkWeSet(xpath, "xpath");
       checkWeSet(document, "document");
       try {
-         setProperty(outputProperty, collect(evaluator.evaluate(xpath, new FileReader(document), multiNodeResult)));
+
+         final String value = collect(evaluator.evaluate(xpath, new FileReader(document), multiNodeResult));
+
+         if (value == null || value.trim().length()==0) {
+            setProperty(outputProperty, defaultValue);
+         } else {
+            setProperty(outputProperty, value);
+         }
+
       } catch (XPathEvaluatorException e) {
          throw new BuildException(e);
       } catch (FileNotFoundException e) {
@@ -80,4 +89,10 @@ public class XPathTask extends Task {
        log("xpath multi-result delimiter: " + delimiter, Project.MSG_VERBOSE);
        this.delimiter = delimiter;
    }
+
+   public void setDefaultValue(String defaultValue) {
+      log("defaultValue: " + defaultValue, Project.MSG_VERBOSE);
+      this.defaultValue = defaultValue;
+   }
+
 }


### PR DESCRIPTION
This change will allow for and explicit value to be set into the output property if the xpath expression can not be resolved.  As a result, it will be easier to detect negative outcomes.
